### PR TITLE
Create 'Text' Interfaces

### DIFF
--- a/pkg/text/options.go
+++ b/pkg/text/options.go
@@ -1,0 +1,4 @@
+package text
+
+// TODO TextOption type
+// TODO TextOption for tokenizer, stemmer, language, similarizer, etc...

--- a/pkg/text/text.go
+++ b/pkg/text/text.go
@@ -1,0 +1,15 @@
+package text
+
+// TODO Text type:
+// TODO func NewText(text string, options ...TextOption) *Text {}
+// TODO func (t *Text) Tokens() *TokenList {}
+// TODO func (t *Text) Words() *TokenList { return t.Tokens() }
+// TODO func (t *Text) Stems() *TokenList {}
+// TODO func (t *Text) Types() *TokenList { return t.Stems() }
+// TODO func (t *Text) Len() int {}
+// TODO func (t *Text) Runes() []rune {}
+// TODO func (t *Text) TokenCount() map[Token]int {}
+// TODO func (t *Text) TypeCount() map[Token]int {}
+// TODO func (t *Text) Vectorize() vector.Vector {}
+// TODO func (t *Text) Similarity(other *Text) float64 {}
+// TODO func (t *Text) Tokenizer/Stemmer/Etc...() Tokenizer/Stemmer/Etc... {}

--- a/pkg/tokens/token.go
+++ b/pkg/tokens/token.go
@@ -1,0 +1,12 @@
+package tokens
+
+// TODO Token type (should be a `string` for now)
+// TODO func (t *Token) Stem() Token {}
+// TODO func (t *Token) Len() int {}
+
+// TODO TokenList type (should be a `[]string` for now and store the Text with it)
+// TODO func (t *TokenList) Text() *Text {}
+// TODO func (t *TokenList) Stems(compact bool) *TokenList {}
+// TODO func (t *TokenList) Len() int {}
+// TODO func (t *TokenList) TokenCount() map[Token]int {}
+// TODO func (t *TokenList) TypeCount() map[Token]int {}

--- a/pkg/tokens/tokenizer.go
+++ b/pkg/tokens/tokenizer.go
@@ -11,6 +11,7 @@ import (
 // ############################################################################
 
 type Tokenizer interface {
+	//TODO refactor to use []Token type for output
 	Tokenize(text string) (tokens []string, err error)
 }
 

--- a/pkg/vector/vector.go
+++ b/pkg/vector/vector.go
@@ -2,3 +2,11 @@ package vector
 
 // Vector is currently implemented by a `[]float64`.
 type Vector []float64
+
+//TODO: func (v Vector) Cosine() (cosine float64, err error) {}
+
+//TODO: func (v Vector) DotProduct(other Vector) (product float64, err error) {}
+
+//TODO: func (v Vector) Magnitude() (length float64) {}
+
+//TODO: func (v Vector) Len() (elements int) {}


### PR DESCRIPTION
### Scope of changes

Create the `text.Text`, `tokens.Token`, and `tokens.TokenList` interfaces for streamlined NLP operations on text chunks and lists of tokens, performed other related refactoring, and added API documentation. 

The user of the NLP library can now use the `text.Text` interface to perform all of the supported NLP operations, such as stemming, tokenization, similarity, etc. instead of having to manage their own tokenizers, stemmers, similarizers, etc. The user will still be able to pass options when creating a `text.Text` which will use the specific tools and options that they provide rather than the defaults.

<!-- Fixes SC-34050 -->

### Type of change

- [ ] bug fix
- [ ] new feature
- [ ] documentation
- [ ] testing
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.